### PR TITLE
Commented out mysql_free_result function calls to resolve issue #2 re…

### DIFF
--- a/csfmanager/csfmanager.php
+++ b/csfmanager/csfmanager.php
@@ -1053,7 +1053,7 @@ function csfmanager_clientarea($vars)
 									$output['allowedips'][$ip_details['id']]['time'] = date("d/m/Y H:i", $ip_details['time']);
 									$output['allowedips'][$ip_details['id']]['expiration'] = date("d/m/Y H:i", $ip_details['expiration']);
 								}
-								mysql_free_result($result);
+								//mysql_free_result($result);
 
 								$output['allowkeys'] = array();
 
@@ -1072,7 +1072,7 @@ function csfmanager_clientarea($vars)
 
 									$output['allowkeys'][$key_details['key_id']]['key_expired'] = ($key_details['key_expire'] <= time());
 								}
-								mysql_free_result($result);
+								//mysql_free_result($result);
 
 							break;
 						}
@@ -1122,7 +1122,7 @@ function csfmanager_clientarea($vars)
 			{
 				$output['services'][] = $product_details;
 			}
-			mysql_free_result($result);
+			//mysql_free_result($result);
 
 			$tplfile = 'csfmanagerproducts';
 		}

--- a/csfmanager/includes/functions.php
+++ b/csfmanager/includes/functions.php
@@ -25,7 +25,7 @@ class csfmanager
 
 			$this->config[$config_details['name']] = $config_details['value'];
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 
 		$this->_loadLanguage();
 	}

--- a/csfmanager/views/allowedlog_default.php
+++ b/csfmanager/views/allowedlog_default.php
@@ -53,7 +53,7 @@ class jcsf_allowedlog_default
 		{
 			$output['data']['list'][] = array_merge($allow_details, array('time' => date("d/m/Y H:i", $allow_details['time']), 'expiration' => date("d/m/Y H:i", $allow_details['expiration'])));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 		
 		$output['data']['current_page'] = (($start / $limit) + 1);
 		$output['data']['total_pages'] = ceil(abs($output['data']['total'] / $limit));
@@ -72,7 +72,7 @@ class jcsf_allowedlog_default
 		{
 			$output['data']['servers'][$server_details['id']] = array_merge($server_details, array('password' => decrypt($server_details['password'], $cc_encryption_hash)));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 		
 		return $output;
 	}

--- a/csfmanager/views/allowkeys_default.php
+++ b/csfmanager/views/allowkeys_default.php
@@ -67,7 +67,7 @@ class jcsf_allowkeys_default
 		{
 			$output['data']['list'][] = array_merge($key_details, array('key_expire_date' => date("d/m/Y H:i", $key_details['key_expire'])));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 		
 		$output['data']['current_page'] = (($start / $limit) + 1);
 		$output['data']['total_pages'] = ceil(abs($output['data']['total'] / $limit));
@@ -85,7 +85,7 @@ class jcsf_allowkeys_default
 		{
 			$output['data']['servers'][$server_details['id']] = array_merge($server_details, array('password' => decrypt($server_details['password'], $cc_encryption_hash)));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 		
 		return $output;
 	}

--- a/csfmanager/views/broadcast_apply.php
+++ b/csfmanager/views/broadcast_apply.php
@@ -43,7 +43,7 @@ class jcsf_broadcast_apply extends jcsf_broadcast_default
 		{
 			$output['data']['servers'][$server_details['id']] = array_merge($server_details, array('password' => decrypt($server_details['password'], $cc_encryption_hash)));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 
 		$config_vars = csfmanager::request_var('configVars', array());
 

--- a/csfmanager/views/broadcast_default.php
+++ b/csfmanager/views/broadcast_default.php
@@ -33,7 +33,7 @@ class jcsf_broadcast_default
 		{
 			$output['data']['servers'][$server_details['id']] = array_merge($server_details, array('password' => decrypt($server_details['password'], $cc_encryption_hash)));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 				
 		return $output;
 	}

--- a/csfmanager/views/broadcast_selectservers.php
+++ b/csfmanager/views/broadcast_selectservers.php
@@ -33,7 +33,7 @@ class jcsf_broadcast_selectservers extends jcsf_broadcast_default
 		{
 			$output['data']['servers'][$server_details['id']] = array_merge($server_details, array('password' => decrypt($server_details['password'], $cc_encryption_hash)));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 
 		$templateserver = csfmanager::request_var('templateserver', 0);
 		

--- a/csfmanager/views/broadcast_send.php
+++ b/csfmanager/views/broadcast_send.php
@@ -57,7 +57,7 @@ class jcsf_broadcast_send extends jcsf_broadcast_default
 		{
 			$output['data']['servers'][$server_details['id']] = array_merge($server_details, array('password' => decrypt($server_details['password'], $cc_encryption_hash)));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 
 		if(!isset($output['data']['servers'][$server_id]))
 		{

--- a/csfmanager/views/broadcast_setconfig.php
+++ b/csfmanager/views/broadcast_setconfig.php
@@ -46,7 +46,7 @@ class jcsf_broadcast_setconfig extends jcsf_broadcast_default
 		{
 			$output['data']['servers'][$server_details['id']] = array_merge($server_details, array('password' => decrypt($server_details['password'], $cc_encryption_hash)));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 
 		$templateserver = csfmanager::request_var('templateserver', 0);
 

--- a/csfmanager/views/firewall_default.php
+++ b/csfmanager/views/firewall_default.php
@@ -33,7 +33,7 @@ class jcsf_firewall_default
 		{
 			$output['data']['servers'][$server_details['id']] = array_merge($server_details, array('password' => decrypt($server_details['password'], $cc_encryption_hash)));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 				
 		return $output;
 	}

--- a/csfmanager/views/firewall_manage.php
+++ b/csfmanager/views/firewall_manage.php
@@ -35,7 +35,7 @@ class jcsf_firewall_manage extends jcsf_firewall_default
 		{
 			$servers[$server_details['id']] = array_merge($server_details, array('password' => decrypt($server_details['password'], $cc_encryption_hash)));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 		
 		$server_details = $servers[$server_id];
 		

--- a/csfmanager/views/generatekey_default.php
+++ b/csfmanager/views/generatekey_default.php
@@ -34,7 +34,7 @@ class jcsf_generatekey_default
 		{
 			$output['data']['servers'][$server_details['id']] = array_merge($server_details, array('password' => decrypt($server_details['password'], $cc_encryption_hash)));
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 		
 		$output['data']['clients'] = array();
 		
@@ -57,7 +57,7 @@ class jcsf_generatekey_default
 		{                     
 			$output['data']['clients'][$client_details['id']] = $client_details;
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 		
 		return $output;
 	}

--- a/csfmanager/views/settings_default.php
+++ b/csfmanager/views/settings_default.php
@@ -34,7 +34,7 @@ class jcsf_settings_default
 		{
 			$output['data']['servers'][$server_details['id']] = array_merge(array('selected' => in_array($server_details['id'], explode(',', $instance->getConfig('servers'))) ? true : false), $server_details);
 		}
-		mysql_free_result($result);
+		//mysql_free_result($result);
 
 		return $output;
 	}


### PR DESCRIPTION
Hello,

I’ve done a quick workaround for issue #2 (and unintentionally #3 as well)  in the branch named “issue_2_php7_compat” in my fork. As you know, this is a particularly insidious bug that has affected a lot of our user base using WHMCS 7 and PHP 7 and is only coming up because their DB compat layer doesn't emulate mysql_free_result(). I think it’d be worthwhile to pull it into the project repository in order to get it into the next release of CSF Manager.

In the long term, rewriting the MySQL functionality to use Capsule as provided by WHMCS is the ideal solution, but this gets the addon working for now.

Thanks!
Lawrence